### PR TITLE
Replace usage of staging module with newer archive module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 pkg/*
 spec/fixtures/*
+Gemfile.lock

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,3 +1,4 @@
+# Main Class
 class plexmediaserver (
   $plex_url                                  =
     $plexmediaserver::params::plex_url,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,16 +24,16 @@ class plexmediaserver (
 ) inherits plexmediaserver::params {
   case $::operatingsystem {
     'Darwin': {
-      staging::deploy { $plex_pkg:
-        source => "${plex_url}/${plex_pkg}",
-        target => '/tmp',
-        before => Package['plexmediaserver'],
+      archive { "/tmp/${plex_pkg}":
+        source       => "${plex_url}/${plex_pkg}",
+        extract_path => '/tmp',
+        extract      => true,
+        before       => Package['plexmediaserver'],
       }
     }
     default: {
-      staging::file { $plex_pkg:
+      archive { "/tmp/${plex_pkg}":
         source => "${plex_url}/${plex_pkg}",
-        target => "/tmp/${plex_pkg}",
         before => Package['plexmediaserver'],
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -13,8 +13,8 @@
       "version_range": ">= 1.0.0"
     },
     {
-      "name": "nanliu-staging",
-      "version_range": ">= 1.0.3"
+      "name": "puppet-archive",
+      "version_range": ">= v0.4.1"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/plexmediaserver_spec.rb
+++ b/spec/classes/plexmediaserver_spec.rb
@@ -47,7 +47,7 @@ describe 'plexmediaserver', :type => :class do
       :architecture    => 'i386',
     }
     end
-    it { should contain_staging__file('plexmediaserver-0.9.12.19.1537-f38ac80.i386.rpm') }
+    it { should contain_archive('/tmp/plexmediaserver-0.9.12.19.1537-f38ac80.i386.rpm') }
   end
 
   context "on a CentOS 64-bit system" do
@@ -58,7 +58,7 @@ describe 'plexmediaserver', :type => :class do
       :architecture    => 'x86_64',
     }
     end
-    it { should contain_staging__file('plexmediaserver-0.9.12.19.1537-f38ac80.x86_64.rpm') }
+    it { should contain_archive('/tmp/plexmediaserver-0.9.12.19.1537-f38ac80.x86_64.rpm') }
   end
 
   context "on a Darwin system" do
@@ -68,7 +68,11 @@ describe 'plexmediaserver', :type => :class do
       :operatingsystem => 'Darwin',
     }
     end
-    it { should contain_staging__deploy('PlexMediaServer-0.9.12.19.1537-f38ac80-OSX.zip') }
+    it { should contain_archive('/tmp/PlexMediaServer-0.9.12.19.1537-f38ac80-OSX.zip').with(
+        extract_path => '/tmp',
+        extract      => true,
+      )
+    }
   end
 
   context "on a Ubuntu 32-bit system" do
@@ -78,7 +82,7 @@ describe 'plexmediaserver', :type => :class do
       :architecture    => 'i386',
     }
     end
-    it { should contain_staging__file('plexmediaserver_0.9.12.19.1537-f38ac80_i386.deb') }
+    it { should contain_archive('/tmp/plexmediaserver_0.9.12.19.1537-f38ac80_i386.deb') }
   end
 
   context "on a Ubuntu 64-bit system" do
@@ -89,7 +93,7 @@ describe 'plexmediaserver', :type => :class do
       :architecture    => 'amd64',
     }
     end
-    it { should contain_staging__file('plexmediaserver_0.9.12.19.1537-f38ac80_amd64.deb') }
+    it { should contain_archive('/tmp/plexmediaserver_0.9.12.19.1537-f38ac80_amd64.deb') }
   end
 
 end


### PR DESCRIPTION
This replaces the staging module with the newer archive module that is under active development and more feature rich.

I've tested this in a vagrant environment with Puppet 4 that I'd be willing to push up if you want to add it reference it in the README so others can quick have a testbed to play with.
